### PR TITLE
Move Javascript to a more maintainable js file.

### DIFF
--- a/assets/js/src/components/database.js
+++ b/assets/js/src/components/database.js
@@ -1,0 +1,96 @@
+window.GatherContent = window.GatherContent || {};
+
+/**
+ * These methods enable the functionality of the table and column Select elements
+ * defined in \GatherContent\Importer\Admin\Mapping\Field_Types\Database
+ */
+
+(function(window, document, $){
+	/**
+	 * @param {HTMLElement} someElement
+	 * @returns {HTMLInputElement}
+	 */
+	function getSiblingHiddenInput(someElement){
+		return someElement.parentElement.querySelector('.hidden-database-table-name');
+	}
+
+	/**
+	 * Clears the selected value on the column selector, and hides all options
+	 * that do not belong to the given table.
+	 *
+	 * @param {HTMLSelectElement} columnSelectElement
+	 * @param {string} tableName
+	 */
+	function resetColumnSelector(columnSelectElement, tableName){
+		columnSelectElement.value = '';
+		columnSelectElement.querySelectorAll('option').forEach(function(o){
+			if(o.getAttribute('data-tablename') === tableName){
+				o.style.display = 'block';
+			}else{
+				o.style.display = 'none';
+			}
+		});
+	}
+
+	/**
+	 * Update the hidden input with the given table and column values.
+	 * Optionally set one at a time by passing undefined for the other.
+	 *
+	 * @param {HTMLInputElement} inputElement
+	 * @param {string|undefined} table
+	 * @param {string|undefined} column
+	 */
+	function setHiddenValue(inputElement, table, column){
+		if(!inputElement.value.includes('.')){
+			inputElement.value = '.';
+		}
+
+		var parts = inputElement.value.split('.');
+
+		if(typeof table === 'string') {
+			parts[0] = table;
+		}
+		if(typeof column === 'string') {
+			parts[1] = column;
+		}
+
+		inputElement.value = parts.join('.');
+	}
+
+	/**
+	 * @param {Event} event
+	 */
+	function columnSelectorChanged(event){
+		/** @var {HTMLSelectElement} columnSelect */
+		var columnSelect = event.target;
+
+		setHiddenValue(
+			getSiblingHiddenInput(columnSelect),
+			undefined,
+			columnSelect.value
+		);
+	}
+
+	/**
+	 * @param {Event} event
+	 */
+	function tableSelectorChanged(event){
+		/** @var {HTMLSelectElement} tableSelect */
+		var tableSelect = event.target;
+
+		resetColumnSelector(
+			tableSelect.parentElement.querySelector('.cw-column-selector'),
+			tableSelect.value
+		);
+
+		setHiddenValue(
+			getSiblingHiddenInput(tableSelect),
+			tableSelect.value,
+			undefined
+		);
+	}
+
+	$(document).on('change', '.cw-table-selector', tableSelectorChanged);
+	$(document).on('change', '.cw-column-selector', columnSelectorChanged);
+})(window, document, jQuery);
+

--- a/includes/classes/admin/enqueue.php
+++ b/includes/classes/admin/enqueue.php
@@ -49,6 +49,7 @@ abstract class Enqueue extends Plugin_Base {
 		}
 
 		\GatherContent\Importer\enqueue_script( 'gc-select2', 'vendor/select2-4.0.13/select2', array( 'jquery' ), '4.0.13' );
+		\GatherContent\Importer\enqueue_script( 'gathercontent-database', 'gathercontent-database', '1.0.0' );
 
 		// If < WP 4.5, we need the newer version of underscore.js
 		if ( ! Utils::enqueued_at_least( 'underscore', '1.8.3' ) ) {

--- a/includes/classes/admin/mapping/field-types/database.php
+++ b/includes/classes/admin/mapping/field-types/database.php
@@ -129,70 +129,13 @@ class Database extends Base implements Type {
 		return $allColumns;
 	}
 
-	private function tableSelectChangedJavascript(): string
-	{
-		return <<<EOT
-/** this runs when the table select is changed */
-const selectElement = this
-const value = selectElement.value
-
-// get the selected options text
-const text = selectElement.options[selectElement.selectedIndex].text
-
-// get the column selector sibling element
-const tableSelect = this.parentElement.querySelector('.cw-column-selector')
-tableSelect.value = ''
-
-// hide any option whose data-tablename is not this text
-tableSelect.querySelectorAll('option').forEach(opt => {
-	const optTableName = opt.getAttribute('data-tablename')
-	opt.style.display = optTableName === text ? 'block' : 'none'
-})
-
-// set this value as the first portion of the hidden element's value
-const hidden = this.parentElement.querySelector('.hidden-database-table-name')
-let hiddenVal = hidden.value
-if(!hiddenVal.includes('.')){
-	hiddenVal = '.'
-}
-const parts = hiddenVal.split('.')
-parts.splice(0, 1, value)
-hidden.value = parts.join('.')
-EOT;
-	}
-
-	private function columSelectChangedJavascript(): string
-	{
-		return <<<EOT
-/** this runs when the column selector is changed */
-const selectElement = this
-const value = selectElement.value
-
-// set this value as the second portion of the hidden element's value
-const hidden = this.parentElement.querySelector('.hidden-database-table-name')
-let hiddenVal = hidden.value
-if(!hiddenVal.includes('.')){
-	hiddenVal = '.'
-}
-const parts = hiddenVal.split('.')
-parts.splice(1, 1, value)
-hidden.value = parts.join('.')
-EOT;
-	}
-
 	public function underscore_template( View $view ) {
-		/**
-		 * @TODO do on-page javascript properly (how???)
-		 */
-		$tableSelectChangedJavascript = $this->tableSelectChangedJavascript();
-		$columnSelectChangedJavascript = $this->columSelectChangedJavascript();
 
 		?>
 		<# if ( '<?php $this->e_type_id(); ?>' === data.field_type ) { #>
 			<div class="wp-type-database-dropdown-container">
 				<select
-					class="gc-select2 wp-type-value-select <?php $this->e_type_id(); ?>"
-					onchange="<?= $tableSelectChangedJavascript ?>"
+					class="cw-table-selector gc-select2 wp-type-value-select <?php $this->e_type_id(); ?>"
 					name=""
 				>
 					<?php $this->underscore_options( $this->post_options ); ?>
@@ -201,7 +144,6 @@ EOT;
 
 				<select
 					class="cw-column-selector"
-					onchange="<?= $columnSelectChangedJavascript ?>"
 					name=""
 				>
 					<option value="">Select a column</option>

--- a/tasks/options/browserify.js
+++ b/tasks/options/browserify.js
@@ -12,6 +12,7 @@ module.exports = {
 		'assets/js/gathercontent-general.js' : 'assets/js/src/components/general.js',
 		'assets/js/gathercontent-single.js'  : 'assets/js/src/components/single.js',
 		'assets/js/gathercontent-mapping.js' : 'assets/js/src/components/mapping.js',
+		'assets/js/gathercontent-database.js' : 'assets/js/src/components/database.js',
 		'assets/js/gathercontent-sync.js'    : 'assets/js/src/components/sync.js'
 	} }
 };

--- a/tasks/options/jshint.js
+++ b/tasks/options/jshint.js
@@ -7,6 +7,7 @@ module.exports = {
 		'!assets/js/src/gathercontent-general.js',
 		'!assets/js/src/gathercontent-single.js',
 		'!assets/js/src/gathercontent-mapping.js',
+		'!assets/js/src/gathercontent-database.js',
 		'!assets/js/src/gathercontent-sync.js'
 	]
 };

--- a/tasks/options/uglify.js
+++ b/tasks/options/uglify.js
@@ -5,6 +5,7 @@ module.exports = {
 			'assets/js/gathercontent-general.min.js' : ['assets/js/gathercontent-general.js'],
 			'assets/js/gathercontent-single.min.js'  : ['assets/js/gathercontent-single.js'],
 			'assets/js/gathercontent-mapping.min.js' : ['assets/js/gathercontent-mapping.js'],
+			'assets/js/gathercontent-database.min.js' : ['assets/js/gathercontent-database.js'],
 			'assets/js/gathercontent-sync.min.js'    : ['assets/js/gathercontent-sync.js']
 		},
 		options: {


### PR DESCRIPTION
Ticket: [FSB-7362](https://bynder.atlassian.net/browse/FSB-7362)

Previously we were just using massive PHP heredoc strings to inject lines of js as inline Select element attributes which works but is difficult and annoying to maintain and debug.

This change adds another file that grunt will build which connects jQuery listeners that enable the functionality of the database mapping selectors.

# ⚠️ Note
Other than jQuery this is very vanilla old school JS to stay compatible with old installations. I've peppered some JSDocs in to help a bit.

Additionally out-of-the box vanilla JS was breaking, possibly due to the app-ification used and underscore templating?

[FSB-7362]: https://bynder.atlassian.net/browse/FSB-7362?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ