### PR TITLE
[GC-4978] Undocumented use of a 3rd Party or external service

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,6 +50,12 @@ Below the text box is a button that will allow you to simply save all of that in
 
 **However**, this information contains potentially senstive data. Please be careful with where you post it. Do not post it in the WordPress support forums.
 
+### Third-Party Services ###
+
+This plugin relies on the following third-party services:
+
+1. **Content Workflow**: This service is used for content management and synchronization between your WordPress site and Content Workflow. For more information, please visit [Content Workflow](https://www.bynder.com/en/products/content-workflow/). The [Terms of Service](https://gathercontent.com/legal/terms-of-service) and [Privacy Policy](https://www.bynder.com/en/legal/privacy-policy/) are available for review.
+
 ## Changelog
 
 ### 1.0.0 ###

--- a/includes/classes/admin/support.php
+++ b/includes/classes/admin/support.php
@@ -136,8 +136,6 @@ class Support extends Base {
 					'page_on_front'           => $this->get_page( 'page_on_front' ),
 					'page_for_posts'          => $this->get_page( 'page_for_posts' ),
 
-					'wp_remote_post'          => $this->wp_remote_post(),
-
 					'session'                 => isset( $_SESSION ) ? 'Enabled' : 'Disabled',
 					'session'                 => esc_html( ini_get( 'session.name' ) ),
 					'session_name'            => esc_html( ini_get( 'session.name' ) ),
@@ -192,26 +190,6 @@ class Support extends Base {
 	public function pre_length() {
 		$length = strlen( $GLOBALS['wpdb']->prefix );
 		return 'Length: ' . $length . ', Status: ' . ( $length > 16 ? 'ERROR: Too Long' : 'Acceptable' );
-	}
-
-	public function wp_remote_post() {
-		$request['cmd'] = '_notify-validate';
-		$response       = wp_remote_post(
-			'https://www.paypal.com/cgi-bin/webscr',
-			array(
-				'sslverify' => false,
-				'timeout'   => 60,
-				'body'      => $request,
-			)
-		);
-
-		if ( ! is_wp_error( $response ) && $response['response']['code'] >= 200 && $response['response']['code'] < 300 ) {
-			$works = 'wp_remote_post() works' . "\n";
-		} else {
-			$works = 'wp_remote_post() does not work' . "\n";
-		}
-
-		return $works;
 	}
 
 	public function active_plugins() {

--- a/includes/views/system-info.php
+++ b/includes/views/system-info.php
@@ -60,8 +60,6 @@ Show On Front:            <?php echo $this->get( 'show_on_front' ), "\n"; ?>
 Page On Front:            <?php echo $this->get( 'page_on_front' ), "\n"; ?>
 Page For Posts:           <?php echo $this->get( 'page_for_posts' ), "\n"; ?>
 
-WP Remote Post:           <?php echo $this->get( 'wp_remote_post' ), "\n"; ?>
-
 Session:                  <?php echo $this->get( 'session' ), "\n"; ?>
 Session Name:             <?php echo $this->get( 'session_name' ), "\n"; ?>
 Cookie Path:              <?php echo $this->get( 'cookie_path' ), "\n"; ?>

--- a/readme.txt
+++ b/readme.txt
@@ -41,6 +41,12 @@ This section describes how to install the plugin and get it working.
 
 For more detailed installation instructions please visit our [Help Centre](http://help.gathercontent.com/importing-and-exporting-content#wordpress-integration).
 
+== Third-Party Services ==
+
+This plugin relies on the following third-party services:
+
+1. **Content Workflow**: This service is used for content management and synchronization between your WordPress site and Content Workflow. For more information, please visit [Content Workflow](https://www.bynder.com/en/products/content-workflow/). The [Terms of Service](https://gathercontent.com/legal/terms-of-service) and [Privacy Policy](https://www.bynder.com/en/legal/privacy-policy/) are available for review.
+
 == Frequently Asked Questions ==
 
 = What is the Support page? =


### PR DESCRIPTION
### GC-4978
Link to ticket: https://bynder.atlassian.net/browse/GC-4978

### What has been done
- WordPress was complaining that we're calling third party services without noting it in the ReadMe. I've added Content Workflow as a third-party service, but removed PayPal from the project altogether.

I've removed PayPal as it seems like a POST request is made to clarify if it works, and that's it, it isn't used for anything else. So without any additional context, I'd opt to remove it entirely. 