### PR TITLE
[GC-4983] Processing the whole input

### DIFF
--- a/includes/classes/admin/enqueue.php
+++ b/includes/classes/admin/enqueue.php
@@ -79,10 +79,17 @@ abstract class Enqueue extends Plugin_Base {
 	 * @return void
 	 */
 	public function script_localize() {
+		/**
+		 * Previously we were pulling the entire $_GET array to localise
+		 * the queryargs used on the front-end. These are the only queryargs
+		 * referenced on the front-end.
+		 */
+		$queryArgs = $this->_get_vals(['flush_cache', 'mapping']);
+
 		wp_localize_script( 'gathercontent', 'GatherContent', apply_filters( 'gathercontent_localized_data', array(
 			'debug'       => Utils::script_debug(),
 			// @codingStandardsIgnoreStart
-			'queryargs'   => $_GET,
+			'queryargs'   => $queryArgs,
 			// @codingStandardsIgnoreEnd
 			'_type_names' => Utils::gc_field_type_name( 'all' ),
 		) ) );

--- a/includes/classes/admin/mapping/items-sync.php
+++ b/includes/classes/admin/mapping/items-sync.php
@@ -133,13 +133,18 @@ class Items_Sync extends Base {
 	 */
 	public function ui_page() {
 		// Output the markup for the JS to build on.
+
+		/**
+		 * Previously the foreach below was iterating over the entire $_GET
+		 * super global. Now we use the specific keys only.
+		 */
+		$hiddenInputs = $this->_get_vals([
+			'page', 'project', 'template', 'sync-items'
+		]);
+
 		?>
 		<input type="hidden" name="mapping_id" id="gc-input-mapping_id" value="<?php echo $this->mapping_id; ?>"/>
-		<?php
-		foreach ( $_GET as $key => $value ) :
-			if ( 'mapping' === $key ) {
-				continue; }
-			?>
+		<?php foreach ( $hiddenInputs as $key => $value ) : ?>
 			<input type="hidden" name="<?php echo esc_attr( $key ); ?>" id="gc-input-<?php echo esc_attr( $key ); ?>" value="<?php echo esc_attr( $value ); ?>" />
 		<?php endforeach; ?>
 		<p class="gc-submit-top"><input type="submit" name="submit" id="gc-submit-2" class="button button-primary button-large" value="<?php esc_html_e( 'Import Selected Items', 'content-workflow' ); ?>"></p>

--- a/includes/classes/base.php
+++ b/includes/classes/base.php
@@ -41,16 +41,11 @@ abstract class Base {
 	 * @throws Exception If the $_GET and $_Post variables are not set on the first initation.
 	 */
 	protected function __construct( array $_get = null, array $_post = null ) {
-		if ( is_array( $_get ) ) {
-			self::$_get = $_get;
-		}
-
-		if ( is_array( $_post ) ) {
-			self::$_post = $_post;
-		}
+		self::$_get = $_get;
+		self::$_post = $_post;
 
 		if ( null === self::$_get || null === self::$_post ) {
-			throw new Exception( __CLASS__ . ' expects the $_GET and $_POST variables as arguments' );
+			throw new Exception( __CLASS__ . ' expects the $_GET and $_POST variables as arguments', 500 );
 		}
 	}
 

--- a/includes/classes/base.php
+++ b/includes/classes/base.php
@@ -67,7 +67,8 @@ abstract class Base {
 	 * @param $keys
 	 * @return array|null
 	 */
-	public function _get_vals($keys){
+	public function _get_vals($keys)
+	{
 		return array_reduce($keys, function($carry, $key){
 			$carry[$key] = $this->_get_val($key);
 

--- a/includes/classes/base.php
+++ b/includes/classes/base.php
@@ -68,6 +68,19 @@ abstract class Base {
 	}
 
 	/**
+	 * Returns an array of the key=>value | null in $_GET if the given keys exist.
+	 * @param $keys
+	 * @return array|null
+	 */
+	public function _get_vals($keys){
+		return array_reduce($keys, function($carry, $key){
+			$carry[$key] = $this->_get_val($key);
+
+			return $carry;
+		}, []);
+	}
+
+	/**
 	 * See if the query array has a value and if its value matches the $value.
 	 *
 	 * @since  3.0.0

--- a/includes/classes/exception.php
+++ b/includes/classes/exception.php
@@ -26,9 +26,9 @@ class Exception extends \Exception {
 	 *
 	 * @since 3.0.0
 	 *
-	 * @param strin $message Exception message.
-	 * @param int   $code    Exception code.
-	 * @param mixed $data    Additional data.
+	 * @param string $message Exception message.
+	 * @param int    $code    Exception code.
+	 * @param mixed  $data    Additional data.
 	 */
 	public function __construct( $message, $code, $data = null ) {
 		parent::__construct( $message, $code );

--- a/includes/classes/sync/async-base.php
+++ b/includes/classes/sync/async-base.php
@@ -49,36 +49,6 @@ abstract class Async_Base extends \WP_Async_Task {
 	}
 
 	/**
-	 * Verify the postback is valid, then fire any scheduled events.
-	 *
-	 * @uses $_POST['_nonce']
-	 * @uses is_user_logged_in()
-	 * @uses add_filter()
-	 * @uses wp_die()
-	 */
-	public function handle_postback() {
-		$data = $_POST;
-
-		$data['ran_action'] = false;
-
-		if ( isset( $_POST['_nonce'] ) && $this->verify_async_nonce( $_POST['_nonce'] ) ) {
-			$data['ran_action'] = $this->run_action();
-		}
-
-		if ( ! General::get_instance()->admin->get_setting( 'log_importer_requests' ) ) {
-			add_filter(
-				'wp_die_handler',
-				function() {
-					die();
-				}
-			);
-			wp_die();
-		}
-
-		die( wp_json_encode( $data ) );
-	}
-
-	/**
 	 * Prepare data for the asynchronous request
 	 *
 	 * @throws Exception If for any reason the request should not happen


### PR DESCRIPTION
ticket: [GC-4983](https://bynder.atlassian.net/browse/GC-4983)

In several places we use the entire `$_GET` and `$_POST` superglobals.

This PR replaces areas that iterate the entire array with specific keys wherever possible.

⚠️ NB: This leaves the super duper base base class `self::$_get = $_GET` as we do not iterate over this but keep a reference to it for use elsewhere now with specific keys (nowhere is the entire array accessed).

[GC-4983]: https://bynder.atlassian.net/browse/GC-4983?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ