### PR TITLE
[GC-5030] Styling within the plugin seems to be broken

### DIFF
--- a/includes/classes/admin/enqueue.php
+++ b/includes/classes/admin/enqueue.php
@@ -24,10 +24,10 @@ abstract class Enqueue extends Plugin_Base {
 	 * @return void
 	 */
 	public function admin_enqueue_style() {
-		\GatherContent\Importer\enqueue_style( 'gc-select2', 'vendor/select2-4.0.13/select2', array(), '4.0.13' );
-		\GatherContent\Importer\enqueue_style( 'gathercontent', 'content-workflow-by-bynder' );
+		\GatherContent\Importer\enqueue_style( 'cwby-select2', 'vendor/select2-4.0.13/select2', array(), '4.0.13' );
+		\GatherContent\Importer\enqueue_style( 'content-workflow-by-bynder', 'gathercontent-importer' );
 
-		do_action( 'gc_admin_enqueue_style' );
+		do_action( 'cwby_admin_enqueue_style' );
 	}
 
 	/**


### PR DESCRIPTION
# OLD

<img width="1507" alt="Screenshot 2024-06-10 at 17 21 45" src="https://github.com/Bynder/cw-wordpress-plugin/assets/1649191/4cba7b68-5744-4374-959e-013f89b0f607">


# NEW

<img width="1512" alt="Screenshot 2024-06-10 at 17 21 34" src="https://github.com/Bynder/cw-wordpress-plugin/assets/1649191/a382f25d-b98b-43e5-bd0b-b6e68b22f702">
