### PR TITLE
[GC-5077] Fixed incompatibility with prefixed database tables

### DIFF
--- a/includes/classes/admin/mapping/field-types/acf.php
+++ b/includes/classes/admin/mapping/field-types/acf.php
@@ -39,7 +39,7 @@ class ACF extends Base implements Type {
 
 		// ============= BUILD FIELD GROUP OPTIONS =============
 		$group_results = $wpdb->get_results(
-			"SELECT * FROM wp_posts WHERE post_type = 'acf-field-group' AND post_status = 'publish' AND post_parent = 0"
+			"SELECT * FROM {$wpdb->posts} WHERE post_type = 'acf-field-group' AND post_status = 'publish' AND post_parent = 0"
 		);
 
 		// FIELD GROUPS


### PR DESCRIPTION
In some wordpress setups you can have prefixed tables. So this ensures we always go to wordpress to ask for the table.