### PR TITLE
[GC-5168] Use wp_enqueue commands

### DIFF
--- a/assets/css/cwby-component-disabled.css
+++ b/assets/css/cwby-component-disabled.css
@@ -1,0 +1,4 @@
+.gc-component-disabled {
+    pointer-events: none;
+    opacity: 0.5;
+}

--- a/assets/css/cwby-component-disabled.min.css
+++ b/assets/css/cwby-component-disabled.min.css
@@ -1,0 +1,1 @@
+.gc-component-disabled{pointer-events:none;opacity:.5}

--- a/includes/classes/admin/mapping-wizard.php
+++ b/includes/classes/admin/mapping-wizard.php
@@ -540,6 +540,8 @@ class Mapping_Wizard extends Base {
 		}
 
 		if ( $template_has_repeatable_fields && ! $is_acf_pro_installed ) {
+		    \GatherContent\Importer\enqueue_style('cwby-component-disabled', 'cwby-component-disabled');
+
 			$notes .= $this->view(
 				'graceful-degradation',
 				array( 'additionalClass' => 'gc-component-disabled' ),

--- a/includes/views/graceful-degradation.php
+++ b/includes/views/graceful-degradation.php
@@ -2,9 +2,3 @@
 <div class="notice notice-error is-dismissible">
 	<p><?php esc_html_e( 'Repeatable content mapping requires the installation of Advanced Custom Fields Pro WordPress Plugin. To enable this functionality, please install and refresh the page.', 'content-workflow-by-bynder' ); ?></p>
 </div>
-<style>
-	.gc-component-disabled {
-		pointer-events: none;
-		opacity: 0.5;
-	}
-</style>

--- a/tasks/options/cssmin.js
+++ b/tasks/options/cssmin.js
@@ -10,7 +10,7 @@ module.exports = {
 		expand: true,
 
 		cwd: 'assets/css/',
-		src: ['gathercontent-importer.css'],
+		src: ['gathercontent-importer.css', 'cwby-component-disabled.css'],
 
 		dest: 'assets/css/',
 		ext: '.min.css'


### PR DESCRIPTION
The graceful degradation was inserting styling outside of the standard Wordpress way of using `enqueue`. So this updates the logic to now enqueue a new css file if required.