### PR TITLE
[GC-5167] Using composer but could not find composer.json file

### DIFF
--- a/tasks/options/compress.js
+++ b/tasks/options/compress.js
@@ -26,7 +26,6 @@ module.exports = {
 			'!**/**.orig',
 			'!**/**.map',
 			'!**/**Gruntfile.js',
-			'!**/**composer.json',
 			'!**/**composer.lock',
 			'!**/**bower.json',
 			'!**/**bower.json',


### PR DESCRIPTION
Wordpress want the composer.json bundled so that it is easier to review the plugin and keep everything open source.