### PR TITLE
[GC-5169] Internationalization: Don't use variables or defines as text, context or text domain parameters.

### DIFF
--- a/includes/views/tmpl-gc-mapping-defaults-tab.php
+++ b/includes/views/tmpl-gc-mapping-defaults-tab.php
@@ -7,7 +7,7 @@
 		<select class="gc-default-mapping-select" data-column="post_type"
 				name="<?php $this->output( 'option_base' ); ?>[post_type]">
 			<# if ( data.initial ) { #>
-			<option selected="selected" value=""><?php esc_html_e( 'Select' ); ?></option>
+			<option selected="selected" value=""><?php esc_html_e( 'Select', 'content-workflow-by-bynder' ); ?></option>
 			<# } #>
 			<?php foreach ( $this->get( 'post_type_options' ) as $option_val => $option_label ) : ?>
 				<option <# if ( '<?php echo esc_attr( $option_val ); ?>' === data.post_type && ! data.initial ) { #>selected="selected"<# } #> value="<?php echo esc_attr( $option_val ); ?>"><?php echo esc_html( $option_label ); ?></option>

--- a/includes/views/tmpl-gc-status-select2.php
+++ b/includes/views/tmpl-gc-status-select2.php
@@ -2,7 +2,7 @@
 <# if ( data.statuses.length ) { #>
 <select class="gc-default-mapping-select gc-select2" data-column="gc_status" data-id="{{ data.id }}" name="gc_status">
 	<option data-color="" data-description=""
-	<# if ( ! data.status.id ) { #>selected="selected"<# } #> value=""><?php esc_html_e( 'Unchanged' ); ?></option>
+	<# if ( ! data.status.id ) { #>selected="selected"<# } #> value=""><?php esc_html_e( 'Unchanged', 'content-workflow-by-bynder' ); ?></option>
 	<# _.each( data.statuses, function( status ) { #>
 	<option data-color="{{ status.color }}" data-description="{{ status.description }}"
 	<# if ( status.id === data.status.id ) { #>selected="selected"<# } #> value="{{ status.id }}">{{ status.display_name


### PR DESCRIPTION
Missed the specific content workflow namespacing for a couple of the translations in the plugin.