### PR TITLE
[GC-5992] [Wordpress] Can't push ACF Pro rows to a repeatable components on CW

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,9 @@
+# :writing_hand: Description
+
+## :bulb: What does this PR do?
+*A short description or list of what this PR is doing*
+
+## :question: Why are we doing this?
+*A short description explaining the need for this PR*
+
+:shipit:

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# Content Workflow (by Bynder) - Version 1.0.2 #
+# Content Workflow (by Bynder) - Version 1.0.3 #
 
 This plugin allows you to transfer content from your Content Workflow projects into your WordPress site and vice-versa.
 

--- a/README.md
+++ b/README.md
@@ -81,6 +81,9 @@ This plugin relies on the following third-party services:
 
 ## Changelog
 
+### 1.0.2 ###
+* Fixed an issue where creating a new row in an ACF PRO repeatable field doesn't create the field on Content Workflow.
+
 ### 1.0.1 ###
 * Updating the plugin listing page to have new assets and an improved description.
 * Fixing small typo within the plugin API stopping the plugin from loading.

--- a/README.md
+++ b/README.md
@@ -81,7 +81,7 @@ This plugin relies on the following third-party services:
 
 ## Changelog
 
-### 1.0.2 ###
+### 1.0.3 ###
 * Fixed an issue where creating a new row in an ACF PRO repeatable field doesn't create the field on Content Workflow.
 
 ### 1.0.1 ###

--- a/gathercontent-importer.php
+++ b/gathercontent-importer.php
@@ -32,8 +32,8 @@
 if ( ! defined( 'ABSPATH' ) ) exit; // Exit if accessed directly
 
 // Useful global constants
-define( 'GATHERCONTENT_VERSION', '1.0.2' );
-define( 'GATHERCONTENT_ENQUEUE_VERSION', '1.0.2' );
+define( 'GATHERCONTENT_VERSION', '1.0.3' );
+define( 'GATHERCONTENT_ENQUEUE_VERSION', '1.0.3' );
 define( 'GATHERCONTENT_SLUG', 'content-workflow' );
 define( 'GATHERCONTENT_PLUGIN', __FILE__ );
 define( 'GATHERCONTENT_URL', plugin_dir_url( __FILE__ ) );

--- a/gathercontent-importer.php
+++ b/gathercontent-importer.php
@@ -2,7 +2,7 @@
 /**
  * Plugin Name:  Content Workflow (by Bynder)
  * Description:  Imports items from Content Workflow to your Wordpress site
- * Version:      1.0.2 
+ * Version:      1.0.2
  * Author:       Content Workflow (by Bynder)
  * Requires PHP: 7.0
  * Author URI:   https://www.bynder.com/products/content-workflow/
@@ -32,8 +32,8 @@
 if ( ! defined( 'ABSPATH' ) ) exit; // Exit if accessed directly
 
 // Useful global constants
-define( 'GATHERCONTENT_VERSION', '1.0.0' );
-define( 'GATHERCONTENT_ENQUEUE_VERSION', '1.0.0' );
+define( 'GATHERCONTENT_VERSION', '1.0.2' );
+define( 'GATHERCONTENT_ENQUEUE_VERSION', '1.0.2' );
 define( 'GATHERCONTENT_SLUG', 'content-workflow' );
 define( 'GATHERCONTENT_PLUGIN', __FILE__ );
 define( 'GATHERCONTENT_URL', plugin_dir_url( __FILE__ ) );

--- a/gathercontent-importer.php
+++ b/gathercontent-importer.php
@@ -2,7 +2,7 @@
 /**
  * Plugin Name:  Content Workflow (by Bynder)
  * Description:  Imports items from Content Workflow to your Wordpress site
- * Version:      1.0.2
+ * Version:      1.0.3
  * Author:       Content Workflow (by Bynder)
  * Requires PHP: 7.0
  * Author URI:   https://www.bynder.com/products/content-workflow/

--- a/includes/classes/sync/push.php
+++ b/includes/classes/sync/push.php
@@ -10,7 +10,6 @@ namespace GatherContent\Importer\Sync;
 use GatherContent\Importer\Post_Types\Template_Mappings;
 use GatherContent\Importer\Mapping_Post;
 use GatherContent\Importer\API;
-use Ramsey\Uuid\Uuid;
 use WP_Error;
 
 /**
@@ -126,12 +125,12 @@ class Push extends Base {
 		if ( empty( $config_update ) ) {
 
 			throw new Exception(
-				sprintf( esc_html__( 'No update data found for that post ID: %d', 'content-workflow-by-bynder' ), esc_html( $this->post->ID ) ),
+				sprintf( esc_html__( 'No update data found for that post ID: %d', 'content-workflow-by-bynder' ), esc_html($this->post->ID) ),
 				__LINE__,
 				array(
-					'post_id'    => esc_html( $this->post->ID ),
-					'mapping_id' => esc_html( $this->mapping->ID ),
-					'item_id'    => esc_html( $this->item->id ) ?? 0,
+					'post_id'    => esc_html($this->post->ID),
+					'mapping_id' => esc_html($this->mapping->ID),
+					'item_id'    => esc_html($this->item->id) ?? 0,
 				)
 			);
 		}

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "gathercontent-importer",
   "title": "Content Workflow (by Bynder)",
   "description": "Imports items from Content Workflow to your wordpress site",
-  "version": "1.0.2",
+  "version": "1.0.3",
   "license": "GPLv2",
   "scripts": {
     "build": "grunt build"

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "gathercontent-importer",
   "title": "Content Workflow (by Bynder)",
   "description": "Imports items from Content Workflow to your wordpress site",
-  "version": "1.0.0",
+  "version": "1.0.2",
   "license": "GPLv2",
   "scripts": {
     "build": "grunt build"

--- a/readme.txt
+++ b/readme.txt
@@ -4,7 +4,7 @@ Donate link: https://www.bynder.com/products/content-workflow/
 Tags: structured content, gather content, gathercontent, import, migrate, export, mapping, production, writing, collaboration, platform, connect, link, gather, client, word, production, bynder, content, workflow
 Requires at least: 5.6.0
 Tested up to: 6.6.0
-Stable tag: 1.0.2
+Stable tag: 1.0.3
 License: GPL-2.0+
 Requires PHP: 7.0
 License URI: https://opensource.org/licenses/GPL-2.0
@@ -67,7 +67,7 @@ Below the text box is a button that will allow you to simply save all of that in
 4. Bulk import your content at scale
 
 == Changelog ==
-= 1.0.2 =
+= 1.0.3 =
 * Fixed an issue where creating a new row in an ACF PRO repeatable field doesn't create the field on Content Workflow.
 
 = 1.0.1 =

--- a/readme.txt
+++ b/readme.txt
@@ -67,6 +67,9 @@ Below the text box is a button that will allow you to simply save all of that in
 4. Bulk import your content at scale
 
 == Changelog ==
+= 1.0.2 =
+* Fixed an issue where creating a new row in an ACF PRO repeatable field doesn't create the field on Content Workflow.
+
 = 1.0.1 =
 * Updating the plugin listing page to have new assets and an improved description.
 * Fixing small typo within the plugin API stopping the plugin from loading.


### PR DESCRIPTION
# :writing_hand: Description

## :bulb: What does this PR do?
When adding a new row to a repeatable component on WordPress, it now creates a new object to hold the data, therefore including it in the request to the API (**the API already handles it**).

## :question: Why are we doing this?
This resolves an existing issue where customers can't push new component instances via WordPress. 

:shipit:

This has been tested with my local WordPress plugin going to production Content Workflow. 