### PR TITLE
[GC-6000] Can't deploy to WordPress

### DIFF
--- a/.github/workflows/deploy-to-wp-org.yml
+++ b/.github/workflows/deploy-to-wp-org.yml
@@ -29,6 +29,10 @@ jobs:
       run: |
         composer install --no-dev
 
+    - name: Install Subversion
+      run: |
+        sudo apt-get update && sudo apt-get install -y subversion
+
     - name: WordPress Plugin Deploy
       id: deploy
       uses: 10up/action-wordpress-plugin-deploy@2.2.2


### PR DESCRIPTION
# :writing_hand: Description

## :bulb: What does this PR do?
Installs subversion for WordPress deploy step

:shipit:
