### PR TITLE
[FSB-9103] WordPress: Plain text fields come through as Rich text when in a component 

### DIFF
--- a/includes/views/tmpl-gc-mapping-tab-row.php
+++ b/includes/views/tmpl-gc-mapping-tab-row.php
@@ -1,4 +1,6 @@
-<?php if ( ! defined( 'ABSPATH' ) ) exit; // Exit if accessed directly
+<?php if ( ! defined( 'ABSPATH' ) ) {
+	exit;
+} // Exit if accessed directly
 /*******************************************
  * Component: Wrapper table - Open
  ***********************************************/ ?>
@@ -26,7 +28,8 @@
 					data.label }} <small>{{ data.subtitle }}</small></strong></a>
 			<ul class="gc-reveal-items-list <# if ( !data.expanded ) { #>hidden<# } #>">
 				<# if ( data.typeName ) { #>
-				<li><strong><?php esc_html_e( 'Type:', 'content-workflow-by-bynder' ); ?></strong> {{ data.typeName }}</li>
+				<li><strong><?php esc_html_e( 'Type:', 'content-workflow-by-bynder' ); ?></strong> {{ data.typeName }}
+				</li>
 				<# } #>
 
 				<# if ( data.limit && data.limit_type ) { #>
@@ -36,7 +39,8 @@
 				<# } #>
 
 				<# if ( data.instructions ) { #>
-				<li><strong><?php esc_html_e( 'Description:', 'content-workflow-by-bynder' ); ?></strong> {{ data.instructions
+				<li><strong><?php esc_html_e( 'Description:', 'content-workflow-by-bynder' ); ?></strong> {{
+					data.instructions
 					}}
 				</li>
 				<# } #>
@@ -99,7 +103,7 @@ var subfield_type_translate = {
 						<# if(( field.field_type )){ #>
 						<li><strong><?php esc_html_e( 'Type:', 'content-workflow-by-bynder' ); ?></strong>
 							<# if(field.field_type === 'text' && field.metadata && field.metadata.is_plain) { #>
-								{{ subfield_type_translate['text_plain'] }}
+							{{ subfield_type_translate['text_plain'] }}
 							<# } else { #>
 							{{ subfield_type_translate[field.field_type] }}
 							<# } #>

--- a/includes/views/tmpl-gc-mapping-tab-row.php
+++ b/includes/views/tmpl-gc-mapping-tab-row.php
@@ -97,8 +97,12 @@ var subfield_type_translate = {
 					</a>
 					<ul class="gc-reveal-items-list gc-reveal-items-hidden hidden">
 						<# if(( field.field_type )){ #>
-						<li><strong><?php esc_html_e( 'Type:', 'content-workflow-by-bynder' ); ?></strong> {{
-							subfield_type_translate[field.field_type] }}
+						<li><strong><?php esc_html_e( 'Type:', 'content-workflow-by-bynder' ); ?></strong>
+							<# if(field.field_type === 'text' && field.metadata && field.metadata.is_plain) { #>
+								{{ subfield_type_translate['text_plain'] }}
+							<# } else { #>
+							{{ subfield_type_translate[field.field_type] }}
+							<# } #>
 						</li>
 						<# } #>
 						<# if(( field.instructions )){ #>


### PR DESCRIPTION
# :writing_hand: Description

## :bulb: What does this PR do?
- Handling plain text field labeling in components
	- Specifically adding the handling to the UI as the data provided works for everything else, so don't want to tweak that.

## :question: Why are we doing this?
It raised some concerns for some customers, in that they thought plain text would be imported as rich text.

:shipit:
