### PR TITLE
[FSB-9104] WordPress: Setting Taxonomy/Terms when setting up a mapping never saves

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# Content Workflow (by Bynder) - Version 1.0.4 #
+# Content Workflow (by Bynder) - Version 1.0.5 #
 
 This plugin allows you to transfer content from your Content Workflow projects into your WordPress site and vice-versa.
 
@@ -80,6 +80,10 @@ This plugin relies on the following third-party services:
    and [Privacy Policy](https://www.bynder.com/en/legal/privacy-policy/) are available for review.
 
 ## Changelog
+
+### 1.0.5 ###
+* Fixes an issue where plain text fields in a component were being imported as rich text fields
+* Fixes an issue where the plugin couldn't map Content Workflow fields to Taxonomy/Terms
 
 ### 1.0.4 ###
 * Adds support for PHP versions 8 to 8.4.*

--- a/gathercontent-importer.php
+++ b/gathercontent-importer.php
@@ -2,7 +2,7 @@
 /**
  * Plugin Name:  Content Workflow (by Bynder)
  * Description:  Imports items from Content Workflow to your Wordpress site
- * Version:      1.0.4
+ * Version:      1.0.5
  * Author:       Content Workflow (by Bynder)
  * Requires PHP: 7.0
  * Author URI:   https://www.bynder.com/products/content-workflow/
@@ -32,8 +32,8 @@
 if ( ! defined( 'ABSPATH' ) ) exit; // Exit if accessed directly
 
 // Useful global constants
-define( 'GATHERCONTENT_VERSION', '1.0.4' );
-define( 'GATHERCONTENT_ENQUEUE_VERSION', '1.0.4' );
+define( 'GATHERCONTENT_VERSION', '1.0.5' );
+define( 'GATHERCONTENT_ENQUEUE_VERSION', '1.0.5' );
 define( 'GATHERCONTENT_SLUG', 'content-workflow' );
 define( 'GATHERCONTENT_PLUGIN', __FILE__ );
 define( 'GATHERCONTENT_URL', plugin_dir_url( __FILE__ ) );

--- a/includes/classes/admin/mapping/field-types/taxonomy.php
+++ b/includes/classes/admin/mapping/field-types/taxonomy.php
@@ -41,7 +41,7 @@ class Taxonomy extends Base implements Type {
 			<# if ( '<?php $this->e_type_id(); ?>' === data.field_type && '<?php echo esc_attr( $type->name ); ?>' === data.post_type ) { #>
 			<select
 				class="wp-type-value-select <?php $this->e_type_id(); ?> wp-taxonomy-<?php echo esc_html( $type->name ); ?>-type"
-				name="<?php $view->get( 'option_base' ); ?>[mapping][{{ data.name }}][value]">
+				name="<?php $view->output( 'option_base' ); ?>[mapping][{{ data.name }}][value]">
 				<?php if ( empty( $type->taxonomies ) ) : ?>
 					<option selected="selected"
 							value=""><?php esc_html_e( 'N/A', 'content-workflow-by-bynder' ); ?></option>

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "gathercontent-importer",
   "title": "Content Workflow (by Bynder)",
   "description": "Imports items from Content Workflow to your wordpress site",
-  "version": "1.0.3",
+  "version": "1.0.5",
   "license": "GPLv2",
   "scripts": {
     "build": "grunt build"

--- a/readme.txt
+++ b/readme.txt
@@ -4,7 +4,7 @@ Donate link: https://www.bynder.com/products/content-workflow/
 Tags: structured content, gather content, gathercontent, import, migrate, export, mapping, production, writing, collaboration, platform, connect, link, gather, client, word, production, bynder, content, workflow
 Requires at least: 5.6.0
 Tested up to: 6.6.0
-Stable tag: 1.0.4
+Stable tag: 1.0.5
 License: GPL-2.0+
 Requires PHP: 7.0
 License URI: https://opensource.org/licenses/GPL-2.0
@@ -67,6 +67,10 @@ Below the text box is a button that will allow you to simply save all of that in
 4. Bulk import your content at scale
 
 == Changelog ==
+
+= 1.0.5 =
+* Fixes an issue where plain text fields in a component were being imported as rich text fields
+* Fixes an issue where the plugin couldn't map Content Workflow fields to Taxonomy/Terms
 
 = 1.0.4 =
 * Adds support for PHP versions 8 to 8.4.*


### PR DESCRIPTION
# :writing_hand: Description

## :bulb: What does this PR do?
- Switched back to output for getting the taxonomy input name
	-  The value passed in will be escaped, so requires the escape handling output provides 
- Also bumps to version 1.0.5 ready for release once this is merged! 

:shipit:
