### PR TITLE
PROPS-2540 add backstage yaml and codeownership

### DIFF
--- a/backstage.yaml
+++ b/backstage.yaml
@@ -1,0 +1,8 @@
+apiVersion: backstage.io/v1alpha1
+kind: Component
+metadata:
+  name: cw-wordpress-plugin
+  description: Bynder cw-wordpress-plugin
+spec:
+  owner: content-workflow
+  lifecycle: production


### PR DESCRIPTION
# :writing_hand: Description

## :bulb: What does this PR do?
Add content-workflow as the code owners as agreed in:

Tech Champions Group
Assigning Assumptions present here https://docs.google.com/spreadsheets/d/1nH72ggyrgbT2lZhqtbpmD32tA57DlW5t/edit?gid=1567830080#gid=1567830080

This pull request adds a new Backstage component definition. It registers the component in the Backstage catalog, specifying its owner and lifecycle.

**Backstage integration:**
Added a backstage.yaml file to register as a component, with metadata including its name, description, owner, and lifecycle.
## :question: Why are we doing this?
*A short description explaining the need for this PR*

:shipit:
