### PR TITLE
GC-7607: WordPress Integration: Fails to pull content for a mapping

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# Content Workflow (by Bynder) - Version 1.0.5 #
+# Content Workflow (by Bynder) - Version 1.0.6 #
 
 This plugin allows you to transfer content from your Content Workflow projects into your WordPress site and vice-versa.
 
@@ -80,6 +80,11 @@ This plugin relies on the following third-party services:
    and [Privacy Policy](https://www.bynder.com/en/legal/privacy-policy/) are available for review.
 
 ## Changelog
+
+### 1.0.6 ###
+* Added a `Clear Pending Imports` button to the template mapping page. This allows you to clear any pending imports
+  that are stuck in the queue, for example if there was an error during import or if the import was cancelled before
+  completion.
 
 ### 1.0.5 ###
 * Fixes an issue where plain text fields in a component were being imported as rich text fields

--- a/gathercontent-importer.php
+++ b/gathercontent-importer.php
@@ -2,7 +2,7 @@
 /**
  * Plugin Name:  Content Workflow (by Bynder)
  * Description:  Imports items from Content Workflow to your Wordpress site
- * Version:      1.0.5
+ * Version:      1.0.6
  * Author:       Content Workflow (by Bynder)
  * Requires PHP: 7.0
  * Author URI:   https://www.bynder.com/products/content-workflow/
@@ -32,8 +32,8 @@
 if ( ! defined( 'ABSPATH' ) ) exit; // Exit if accessed directly
 
 // Useful global constants
-define( 'GATHERCONTENT_VERSION', '1.0.5' );
-define( 'GATHERCONTENT_ENQUEUE_VERSION', '1.0.5' );
+define( 'GATHERCONTENT_VERSION', '1.0.6' );
+define( 'GATHERCONTENT_ENQUEUE_VERSION', '1.0.6' );
 define( 'GATHERCONTENT_SLUG', 'content-workflow' );
 define( 'GATHERCONTENT_PLUGIN', __FILE__ );
 define( 'GATHERCONTENT_URL', plugin_dir_url( __FILE__ ) );

--- a/includes/classes/post-types/template-mappings.php
+++ b/includes/classes/post-types/template-mappings.php
@@ -774,11 +774,6 @@ class Template_Mappings extends Base {
 	}
 
 	public function add_clear_pending_imports_button() {
-		// We only want this to show when in debug mode
-		if (!defined('WP_DEBUG') || !WP_DEBUG) {
-			return;
-		}
-
 		$screen = get_current_screen();
 
 		// Only show on template mappings list page

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "gathercontent-importer",
   "title": "Content Workflow (by Bynder)",
   "description": "Imports items from Content Workflow to your wordpress site",
-  "version": "1.0.5",
+  "version": "1.0.6",
   "license": "GPLv2",
   "scripts": {
     "build": "grunt build"

--- a/readme.txt
+++ b/readme.txt
@@ -4,7 +4,7 @@ Donate link: https://www.bynder.com/products/content-workflow/
 Tags: structured content, gather content, gathercontent, import, migrate, export, mapping, production, writing, collaboration, platform, connect, link, gather, client, word, production, bynder, content, workflow
 Requires at least: 5.6.0
 Tested up to: 6.6.0
-Stable tag: 1.0.5
+Stable tag: 1.0.6
 License: GPL-2.0+
 Requires PHP: 7.0
 License URI: https://opensource.org/licenses/GPL-2.0
@@ -67,6 +67,11 @@ Below the text box is a button that will allow you to simply save all of that in
 4. Bulk import your content at scale
 
 == Changelog ==
+
+= 1.0.6 =
+* Added a `Clear Pending Imports` button to the template mapping page. This allows you to clear any pending imports
+that are stuck in the queue, for example if there was an error during import or if the import was cancelled before
+completion.
 
 = 1.0.5 =
 * Fixes an issue where plain text fields in a component were being imported as rich text fields


### PR DESCRIPTION
# :writing_hand: Description

## :bulb: What does this PR do?
- Making the `Clear Pending Imports` button available at all time (not just in debug mode) 

## :question: Why are we doing this?
- A customer has run into the famous stuck on 25% issues when importing. This typically is related to an import that failed previously for any number of reasons. This button clears the relevant DB tables and essentially let's you try again. 

:shipit:
