### PR TITLE
Fix ACF group mapping validation in push sync

### DIFF
--- a/includes/classes/sync/push.php
+++ b/includes/classes/sync/push.php
@@ -812,10 +812,18 @@ class Push extends Base {
 				}
 			}
 			$groupData = [];
-			foreach ( $field_group as $group ) {
-				// Combine keys from componentFieldsKeys with values from the current group
-				$new_group   = array_combine( $componentFieldsKeys, $group );
-				$groupData[] = $new_group;
+			if ( is_array( $field_group ) ) {
+				foreach ( $field_group as $group ) {
+					if ( ! is_array( $group ) ) {
+						continue;
+					}
+					if ( count( $componentFieldsKeys ) !== count( $group ) ) {
+						error_log( 'Content Workflow ACF mapping mismatch for group key ' . $group_key . ': componentFieldsKeys=' . count( $componentFieldsKeys ) . ' group=' . count( $group ) );
+						continue;
+					}
+					$new_group   = array_combine( $componentFieldsKeys, $group );
+					$groupData[] = $new_group;
+				}
 			}
 
 


### PR DESCRIPTION
### Summary

This PR hardens the push sync when building ACF group mappings.

### What changed

- Skip non-array group entries before mapping.
- Guard against key/value count mismatches before calling `array_combine()`.
- Log mapping mismatches to simplify debugging malformed data.

### Why

- `array_combine()` can generate invalid mappings or warnings when the ACF group shape is not what we expect.
- This fix prevents sync failures caused by malformed or inconsistent field data.

### Testing

- Verified the push sync path with valid group data.
- Verified malformed group entries are skipped safely.
- Verified mismatched key/value counts no longer break the sync.