### PR TITLE
GC-7874: bump GitHub Actions to drop Node 20 runtime

### DIFF
--- a/.github/workflows/deploy-to-wp-org.yml
+++ b/.github/workflows/deploy-to-wp-org.yml
@@ -11,10 +11,10 @@ jobs:
     steps:
 
     - name: Checkout code
-      uses: actions/checkout@v4
+      uses: actions/checkout@v6
 
     - name: Install NodeJS
-      uses: actions/setup-node@v4
+      uses: actions/setup-node@v6
       with:
         node-version-file: "package.json"
         cache-dependency-path: 'package-lock.json'


### PR DESCRIPTION
## Summary

Part of [GC-7874](https://bynder.atlassian.net/browse/GC-7874) — GitHub is removing the Node.js 20 runtime, so action versions that run on Node 20 must be bumped.

## Changes
- `actions/checkout@v4 -> v6`
- `actions/setup-node@v4 -> v6`

## Refs
- https://bynder.atlassian.net/wiki/spaces/BE/pages/6259376131/


[GC-7874]: https://bynder.atlassian.net/browse/GC-7874?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ