### PR TITLE
Fix guard against null field values and ACF component mismatches

### DIFF
--- a/includes/classes/sync/base.php
+++ b/includes/classes/sync/base.php
@@ -578,13 +578,13 @@ abstract class Base extends Plugin_Base {
 			);
 		}
 
-		if ( isset( $metadata->choice_fields->otherOption ) ) {
+		if ( isset( $metadata->choice_fields->otherOption ) && ! empty( $field_value ) ) {
 			$option         = $metadata->choice_fields->otherOption;
 			$matched_option = wp_list_filter( $field_value, array( 'id' => $option->optionId ) );
 
 			$options[] = (object) [
 				'name'     => $option->optionId,
-				'label'    => $field_value[0]->label,
+				'label'    => isset( $field_value[0]->label ) ? $field_value[0]->label : $option->optionId,
 				'selected' => ! empty( $matched_option ),
 			];
 		}

--- a/includes/classes/sync/push.php
+++ b/includes/classes/sync/push.php
@@ -812,10 +812,18 @@ class Push extends Base {
 				}
 			}
 			$groupData = [];
-			foreach ( $field_group as $group ) {
-				// Combine keys from componentFieldsKeys with values from the current group
-				$new_group   = array_combine( $componentFieldsKeys, $group );
-				$groupData[] = $new_group;
+			if ( is_array( $field_group ) ) {
+				foreach ( $field_group as $group ) {
+					if ( ! is_array( $group ) ) {
+						continue;
+					}
+					if ( count( $componentFieldsKeys ) !== count( $group ) ) {
+						error_log( 'Content Workflow ACF mapping mismatch for group key ' . $group_key . ': componentFieldsKeys=' . count( $componentFieldsKeys ) . ' group=' . count( $group ) );
+						continue;
+					}
+					$new_group   = array_combine( $componentFieldsKeys, $group );
+					$groupData[] = $new_group;
+				}
 			}
 
 


### PR DESCRIPTION
# :writing_hand: Description

## :bulb: What does this PR do?
* Guard `$field_value` emptiness before accessing `$field_value[0]->label` in the `otherOption` path of radio/checkbox fields (`base.php`, also falls back to `$option->optionId` if `label` is not set
* Guard `array_combine()` in `set_acf_field_value()` (`push.php`): skip rows where `$componentFieldsKeys` count does not match the ACF group values count, and log the mismatch instead of throwing a fatal error

## :question: Why are we doing this?
* On templates where radio or checkbox fields have an empty `otherOption`, `$field_value` can be null, causing a `TypeError` on `$field_value[0]->label` that silently killed the sync.
* On ACF component mappings where the number of fields declared in Content Workflow does not match the number of values in the ACF group, calling `array_combine()` with mismatched arrays throws a `ValueError` and leaves the item stuck in an "in progress" push state with a 500 error.

:shipit:
